### PR TITLE
Generate .html.erb files instead of .html files.

### DIFF
--- a/wrc/wrc.py
+++ b/wrc/wrc.py
@@ -205,7 +205,7 @@ def run():
         check_output(options.output)
         errors, warnings = generate(WCADocumentHtml,
                                     (input_regulations, input_guidelines),
-                                    ["index.html", "guidelines.html"],
+                                    ["index.html.erb", "guidelines.html.erb"],
                                     options)
     elif options.target == "pdf":
         check_output(options.output)


### PR DESCRIPTION
This fixes https://github.com/thewca/worldcubeassociation.org/issues/1347 (which was caused by us upgrading to Rails 5).

Looks like it was really this simple! In action:

```
~/gitting/wca-regulations-compiler @kaladin> python2 -m wrc.wrc --target=html ../wca-regulations --output=/tmp
Compiled Regulations and Guidelines, generating HTML...
Successfully written the content to /tmp/index.html.erb
Successfully written the content to /tmp/guidelines.html.erb
```