### PR TITLE
Add enable-local-file-access flag to wkhtml

### DIFF
--- a/wrc/wrc.py
+++ b/wrc/wrc.py
@@ -96,6 +96,7 @@ def html_to_pdf(tmp_filenames, output_directory, lang_options):
     wkthml_cmd.extend(["--footer-html", footer_file])
     wkthml_cmd.extend(["--header-spacing", "8"])
     wkthml_cmd.extend(["--footer-spacing", "8"])
+    wkthml_cmd.extend(["--enable-local-file-access"])
     wkthml_cmd.append(input_html)
     wkthml_cmd.append(output_directory + "/" + lang_options['pdf'] + '.pdf')
     try:


### PR DESCRIPTION
preparing for a breaking change in 0.12.6, but the option is already present in older versions as well (in particular, it **is** present in 0.12.4 which we're currently using)