### PR TITLE
Include guideline label in generated JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.egg-info
 
 .idea/
+build/

--- a/wrc/codegen/cgjson.py
+++ b/wrc/codegen/cgjson.py
@@ -49,17 +49,23 @@ class WCADocumentJSON(CGDocument):
 
 
     def visitRule(self, reg):
+        label = None
         url = "/regulations/"
-        label = ""
+
         if isinstance(reg, Guideline):
             url += "guidelines.html"
             label = reg.labelname
+
         url += "#" + reg.number
-        self.codegen.append({'class': 'regulation',
-                             'id': reg.number,
-                             'guideline_label': label,
-                             'content_html': simple_md2html(reg.text, self.urls),
-                             'url': url})
+        reg_dict = {
+            'class': 'regulation',
+            'id': reg.number,
+            'content_html': simple_md2html(reg.text, self.urls),
+            'url': url
+        }
+        if label:
+            reg_dict.update({'guideline_label': label})
+        self.codegen.append(reg_dict)
         retval = super(WCADocumentJSON, self).visitRule(reg)
         return retval
 

--- a/wrc/codegen/cgjson.py
+++ b/wrc/codegen/cgjson.py
@@ -50,10 +50,14 @@ class WCADocumentJSON(CGDocument):
 
     def visitRule(self, reg):
         url = "/regulations/"
+        label = ""
         if isinstance(reg, Guideline):
             url += "guidelines.html"
+            label = reg.labelname
         url += "#" + reg.number
-        self.codegen.append({'class': 'regulation', 'id': reg.number,
+        self.codegen.append({'class': 'regulation',
+                             'id': reg.number,
+                             'guideline_label': label,
                              'content_html': simple_md2html(reg.text, self.urls),
                              'url': url})
         retval = super(WCADocumentJSON, self).visitRule(reg)


### PR DESCRIPTION
See [this](https://github.com/thewca/worldcubeassociation.org/issues/2538#issuecomment-531379563) comment.
Closes #16 

Added `guideline_label` field to the generated JSON. The field will be an empty string for regulations.

TODO: bump version.