### PR TITLE
fix: point to `main` instead of `master` branch

### DIFF
--- a/wrc/codegen/cghtml.py
+++ b/wrc/codegen/cghtml.py
@@ -6,7 +6,7 @@ from wrc.codegen.cg import CGDocument
 REPO_REG = "https://github.com/thewca/wca-regulations"
 REPO_TRANS = "https://github.com/thewca/wca-regulations-translations"
 BRANCH_REG = "official"
-BRANCH_TRANS = "master"
+BRANCH_TRANS = "main"
 ID_REG = "official"
 ID_TRANS = "wca-regulations-translations"
 TOC_ELEM = '<li>{name}{sep}<a href="#{anchor}">{title}</a></li>\n'


### PR DESCRIPTION
For the WCA website, an issue was reported where the link to the translated regulations points to an old version of the repo which used `master` instead of `main`.

This directly links to the current default branch called `main` without the message on the top of the page.

Fixes https://github.com/thewca/worldcubeassociation.org/issues/7367