### PR TITLE
Fix broken /guidelines link

### DIFF
--- a/wrc/codegen/cghtml.py
+++ b/wrc/codegen/cghtml.py
@@ -92,7 +92,7 @@ class WCADocumentHtml(CGDocument):
     def __init__(self, versionhash, language, pdf):
         super(WCADocumentHtml, self).__init__(str)
         self.regset = set()
-        self.urls = {'regulations': './', 'guidelines': './guidelines.html',
+        self.urls = {'regulations': './', 'guidelines': './regulations/guidelines.html',
                      'pdf': pdf}
         self.language = language
 


### PR DESCRIPTION
It has been reported that the guideline hyperlink in the sentence "The WCA Regulations are also supplemented by the [WCA Guidelines](https://www.worldcubeassociation.org/guidelines.html#)." on the [regulations page](https://www.worldcubeassociation.org/regulations) doesn't work - it should redirect to `/regulations/guidelines.html#`, while it currently only redirects to `/guidelines.html#`.

I've taken a quick look and I think the change I've committed is the needed one - but I'm not familiar enough with building the regulations to test it, or to even be confident that this change is correct.