### PR TITLE
Remove pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "Tool to build and perform checks on WCA Regulations and Guidelines"
 readme = "README.md"
-requires-python = ">=3.0"
+requires-python = ">=3.9"
 
 [project.license]
 text = "GPLv3"

--- a/wrc/codegen/cghtmltopdf.py
+++ b/wrc/codegen/cghtmltopdf.py
@@ -1,6 +1,6 @@
 ''' Backend for PDF using html. '''
 import os.path
-import pkg_resources
+from importlib.resources import files, as_file
 from wrc.sema.ast import Rule, LabelDecl, Article
 from wrc.codegen.cghtml import WCADocumentHtml
 
@@ -120,13 +120,13 @@ class WCADocumentHtmlToPdf(WCADocumentHtml):
         fonts = {'normal': 'cmunrm.otf', 'italic': 'cmunti.otf',
                  'bold': 'cmunbx.otf', 'bi': 'cmunbi.otf'}
         for name in fonts.keys():
-            fontfile = pkg_resources.resource_filename("wrc", "data/" + fonts[name])
+            fontfile = as_file(files("wrc").joinpath(f"data/{filename}"))
             if not os.path.isabs(fontfile):
                 fontfile = os.path.abspath(fontfile)
             fonts[name] = fontfile
         self.codegen += CSS_FONTS.format(normal=fonts['normal'], bold=fonts['bold'],
                                          italic=fonts['italic'], bi=fonts['bi'])
-        self.codegen += pkg_resources.resource_string("wrc", "data/htmltopdf.css").decode("utf-8")
+        self.codegen += files("wrc").joinpath("data/htmltopdf.css").read_text(encoding="utf-8")
         self.codegen += '</style></head><body class="%s"><div>\n' % self.language
         self.codegen += HTML_TITLE.format(title=TITLE, author=AUTHOR)
         retval = super(WCADocumentHtmlToPdf, self).visitWCARegulations(document)

--- a/wrc/wrc.py
+++ b/wrc/wrc.py
@@ -3,7 +3,7 @@ import json
 import sys
 import os
 from subprocess import check_call, CalledProcessError
-import pkg_resources
+from importlib.resources import files, as_file
 from .parse.parser import WCAParser
 from .sema.ast import WCARegulations, WCAGuidelines, WCAStates, Ruleset
 from .codegen.cghtml import WCADocumentHtml
@@ -122,10 +122,12 @@ def html_to_pdf(tmp_filenames, output_directory, lang_options):
     wkthml_cmd.extend(["--margin-right", "18"])
     wkthml_cmd.extend(["--page-size", "Letter"])
     # Header and Footer
-    header_file = pkg_resources.resource_filename("wrc", "data/header.html")
-    footer_file = pkg_resources.resource_filename("wrc", "data/footer.html")
-    wkthml_cmd.extend(["--header-html", header_file])
-    wkthml_cmd.extend(["--footer-html", footer_file])
+    header_resource = files("wrc").joinpath("data/header.html")
+    footer_resource = files("wrc").joinpath("data/footer.html")
+    header_file = as_file(header_resource)
+    footer_file = as_file(footer_resource)
+    wkthml_cmd.extend(["--header-html", str(header_file)])
+    wkthml_cmd.extend(["--footer-html", str(footer_file)])
     wkthml_cmd.extend(["--header-spacing", "8"])
     wkthml_cmd.extend(["--footer-spacing", "8"])
     wkthml_cmd.extend(["--enable-local-file-access"])
@@ -219,7 +221,7 @@ def check_output(directory):
 
 def languages(display=True):
     # Get information about languages from the config file (tex encoding, pdf filename, etc)
-    languages_json_str = pkg_resources.resource_string(__name__, "data/languages.json").decode('utf-8')
+    languages_json_str = files(__package__).joinpath("data/languages.json").read_text(encoding="utf-8")
     languages_info = json.loads(languages_json_str)
 
     if display:


### PR DESCRIPTION
`pkg_resources` was removed in Python 3.12 so the compiler is broken on newer machines. Some of this migration was chatgpt generated, but I did test it by running this dockerfile:

```
FROM python:3.12-bookworm
RUN apt update
RUN apt install -y fonts-unfonts-core fonts-wqy-microhei fonts-ipafont
RUN pip install ply unidecode
COPY . .
RUN mkdir /build
RUN python -m wrc.wrc ./wca-regulations.md --target=html --output=/build
```
and then doing
```
docker create wrc
docker cp $ID_FROM_THE_PREVIOUS_OUTPUT:/build .
```
And the file looks good to me?